### PR TITLE
chore: cleanup errors and logs

### DIFF
--- a/common/proxyerrors/4xx.go
+++ b/common/proxyerrors/4xx.go
@@ -12,6 +12,7 @@ import (
 )
 
 func Is400(err error) bool {
+	var parsingError ParsingError
 	var certHexDecodingError CertHexDecodingError
 	var invalidBackendErr common.InvalidBackendError
 	var unmarshalJSONErr UnmarshalJSONError
@@ -19,6 +20,7 @@ func Is400(err error) bool {
 	var readRequestBodyErr ReadRequestBodyError
 	var s3KeccakKeyValueMismatchErr s3.Keccak256KeyValueMismatchError
 	return errors.Is(err, ErrProxyOversizedBlob) ||
+		errors.As(err, &parsingError) ||
 		errors.As(err, &certHexDecodingError) ||
 		errors.As(err, &invalidBackendErr) ||
 		errors.As(err, &unmarshalJSONErr) ||
@@ -123,4 +125,19 @@ func NewUnmarshalJSONError(err error) UnmarshalJSONError {
 
 func (me UnmarshalJSONError) Error() string {
 	return fmt.Sprintf("unmarshalling JSON: %s", me.err.Error())
+}
+
+// ParsingError is a very coarse-grained error that's used as a catch-all for any parsing errors
+// like parsing a hex string, or parsing a version byte from the request path, reading a query param, etc.
+type ParsingError struct {
+	err error
+}
+
+func NewParsingError(err error) ParsingError {
+	return ParsingError{
+		err: err,
+	}
+}
+func (me ParsingError) Error() string {
+	return fmt.Sprintf("parsing error: %s", me.err.Error())
 }

--- a/server/handlers_cert_test.go
+++ b/server/handlers_cert_test.go
@@ -162,7 +162,6 @@ func TestHandlerPutSuccess(t *testing.T) {
 				mockStorageMgr.EXPECT().Put(
 					gomock.Any(),
 					gomock.Any(),
-					gomock.Any(),
 					gomock.Any()).Return([]byte(testCommitStr), nil)
 			},
 			expectedCode: http.StatusOK,
@@ -186,7 +185,6 @@ func TestHandlerPutSuccess(t *testing.T) {
 			body: []byte("some data that will successfully be written to EigenDA"),
 			mockBehavior: func() {
 				mockStorageMgr.EXPECT().Put(
-					gomock.Any(),
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any()).Return([]byte(testCommitStr), nil)
@@ -284,7 +282,7 @@ func TestHandlerPutErrors(t *testing.T) {
 			t.Run(tt.name+" / "+mode.name, func(t *testing.T) {
 				t.Log(tt.name + " / " + mode.name)
 				mockStorageMgr.EXPECT().
-					Put(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Put(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, tt.mockStorageMgrPutReturnedErr)
 
 				req := httptest.NewRequest(

--- a/server/middleware/logging.go
+++ b/server/middleware/logging.go
@@ -25,14 +25,17 @@ func withLogging(
 
 		args := []any{
 			"method", r.Method, "url", r.URL,
-			"status", scw.status, "duration", time.Since(start),
 			"commitment_mode", mode, "cert_version", getCertVersion(r),
+			"status", scw.status, "duration", time.Since(start),
 		}
 
 		if err != nil {
 			args = append(args, "error", err.Error())
 			log.Error("request completed with error", args...)
 		} else {
+			// This log line largely duplicates the logging in the handlers.
+			// Only difference being that we have duration here, whereas the handlers log the cert.
+			// TODO: should we also pass the cert via the requestContext to rid of the log lines in the handlers?
 			log.Info("request completed", args...)
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -116,12 +116,6 @@ func (svr *Server) SetDispersalBackend(backend common.EigenDABackend) {
 	svr.sm.SetDispersalBackend(backend)
 }
 
-func (svr *Server) writeResponse(w http.ResponseWriter, data []byte) {
-	if _, err := w.Write(data); err != nil {
-		http.Error(w, fmt.Sprintf("failed to write response: %v", err), http.StatusInternalServerError)
-	}
-}
-
 func (svr *Server) Port() int {
 	// read from listener
 	_, portStr, _ := net.SplitHostPort(svr.listener.Addr().String())

--- a/store/manager.go
+++ b/store/manager.go
@@ -19,7 +19,7 @@ import (
 // IManager ... read/write interface
 type IManager interface {
 	// See [Manager.Put]
-	Put(ctx context.Context, cm commitments.CommitmentMode, key, value []byte) ([]byte, error)
+	Put(ctx context.Context, cm commitments.CommitmentMode, value []byte) ([]byte, error)
 	// See [Manager.Get]
 	Get(ctx context.Context, versionedCert certs.VersionedCert,
 		cm commitments.CommitmentMode, verifyOpts common.CertVerificationOpts) ([]byte, error)
@@ -154,7 +154,7 @@ func (m *Manager) Get(ctx context.Context,
 }
 
 // Put ... inserts a value into a storage backend based on the commitment mode
-func (m *Manager) Put(ctx context.Context, cm commitments.CommitmentMode, key, value []byte) ([]byte, error) {
+func (m *Manager) Put(ctx context.Context, cm commitments.CommitmentMode, value []byte) ([]byte, error) {
 	var commit []byte
 	var err error
 

--- a/test/mocks/manager.go
+++ b/test/mocks/manager.go
@@ -88,18 +88,18 @@ func (mr *MockIManagerMockRecorder) GetOPKeccakValueFromS3(ctx, key any) *gomock
 }
 
 // Put mocks base method.
-func (m *MockIManager) Put(ctx context.Context, cm commitments.CommitmentMode, key, value []byte) ([]byte, error) {
+func (m *MockIManager) Put(ctx context.Context, cm commitments.CommitmentMode, value []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", ctx, cm, key, value)
+	ret := m.ctrl.Call(m, "Put", ctx, cm, value)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockIManagerMockRecorder) Put(ctx, cm, key, value any) *gomock.Call {
+func (mr *MockIManagerMockRecorder) Put(ctx, cm, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockIManager)(nil).Put), ctx, cm, key, value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockIManager)(nil).Put), ctx, cm, value)
 }
 
 // PutOPKeccakPairInS3 mocks base method.


### PR DESCRIPTION
Closes DAINT-289
Closes DAINT-276
Closes #291 
Closes #282 

We were still returning 500s instead of 400s in certain cases, and doubly logging some things. Made all request logs structured (following something like https://brandur.org/nanoglyphs/025-logs).

Also cleaned up the manager's PUT interface which had an unused parameter (not sure why this wasn't caught by our linters...)

<!-- If your PR fixes an open issue, use `Closes #NNN` to link your PR with the
issue, replacing `#NNN` with the issue number you are fixing -->

## Fixes Issue

<!-- Example: Closes #NNN -->
Fixes #

## Changes proposed

<!-- List all the proposed changes in your PR -->
<!-- Add the screenshots of the changes below if applicable -->

### Screenshots (Optional)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->
